### PR TITLE
LIMS_2764_More_Table_Columns_everywhere

### DIFF
--- a/src/bika/lims/controlpanel/bika_instruments.py
+++ b/src/bika/lims/controlpanel/bika_instruments.py
@@ -167,9 +167,7 @@ class InstrumentsView(BikaListingView):
         if expiry_date is None:
             item["ExpiryDate"] = _("No date set")
         else:
-
-            item["ExpiryDate"] = expiry_date.asdatetime().strftime(
-                self.date_format_short)
+            item["ExpiryDate"] = self.ulocalized_time(expiry_date, long_format=0)
 
         methods = obj.getMethods()
         if methods:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Issue: LIMS 2764 More Table Columns everywhere (https://jira.bikalabs.com/browse/LIMS-2764)

## Current behavior before PR

Expiry date for instruments was defaulting to 00:00

## Desired behavior after PR is merged

Expiry date is the date that the instrument is valid till.
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
