### PR TITLE
LIMS-3498 Due date not displayed on WSs, resolution

### DIFF
--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -830,6 +830,8 @@ class AnalysesView(ListingView):
             img = get_image('late.png', title=t(_("Late Analysis")),
                             width='16px', height='16px')
             item['replace']['DueDate'] = '{} {}'.format(due_date_str, img)
+        else:
+            item['replace']['DueDate'] = due_date_str
 
     def _folder_item_result(self, analysis_brain, item):
         """Set the analysis' result to the item passed in.


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://jira.bikalabs.com/browse/LIMS-3498

## Current behavior before PR

Due date of samples not appearing in Worksheets

## Desired behavior after PR is merged

Due dates appear on Worksheets

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
