### PR TITLE
LIMS-3597-Default-Batch-Date resolution

### DIFF
--- a/src/bika/lims/content/batch.py
+++ b/src/bika/lims/content/batch.py
@@ -46,6 +46,7 @@ from Products.Archetypes.public import registerType
 from Products.CMFCore.utils import getToolByName
 from senaite.core.catalog import SAMPLE_CATALOG
 from zope.interface import implements
+from DateTime.DateTime import DateTime
 
 
 @indexer(IBatch)
@@ -98,6 +99,7 @@ schema = BikaFolderSchema.copy() + Schema((
     DateTimeField(
         'BatchDate',
         required=False,
+        default_method=DateTime,
         widget=DateTimeWidget(
             label=_('Date'),
         ),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://jira.bikalabs.com/browse/LIMS-3597

## Current behavior before PR

No default date

## Desired behavior after PR is merged

Default date = current date.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
