### PR TITLE
LIMS 3648 Container-lookup empty

### DIFF
--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -550,7 +550,7 @@ schema = BikaSchema.copy() + Schema((
     UIDReferenceField(
         'Container',
         required=0,
-        allowed_types='SampleContainer',
+        allowed_types='Container',
         mode="rw",
         read_permission=View,
         write_permission=FieldEditContainer,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://jira.bikalabs.com/browse/LIMS-3648

## Current behavior before PR

Container lookup does not return anything. 

## Desired behavior after PR is merged

Container lookup shows all added containers.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
